### PR TITLE
Correct Class Case

### DIFF
--- a/lib/awsmap/mappers/docker_compose.py
+++ b/lib/awsmap/mappers/docker_compose.py
@@ -37,7 +37,7 @@ class DockerComposeMapper(Map):
                     service_containers[service_name] = container
                     if "volumes" in service_config.keys():
                         for volume in service_config['volumes']:
-                            container << Filestorage("\n".join(volume.split(":")))
+                            container << FileStorage("\n".join(volume.split(":")))
 
                     if "ports" in service_config.keys():
                         for port in service_config['ports']:

--- a/lib/awsmap/mappers/docker_compose.py
+++ b/lib/awsmap/mappers/docker_compose.py
@@ -5,7 +5,7 @@ from lib.awsmap.map import Map
 from diagrams import Cluster, Diagram, Edge
 from diagrams.aws.network import VPC, InternetGateway, NATGateway, ClientVpn, SiteToSiteVpn
 
-from diagrams.oci.storage import Filestorage
+from diagrams.oci.storage import FileStorage
 from diagrams.oci.compute import Container
 
 class DockerComposeMapper(Map):


### PR DESCRIPTION
Why?
The diagrams lib has a different name for the class with the latest version 0.17.0, see https://github.com/mingrammer/diagrams/blob/master/diagrams/oci/storage.py#L63

What?
Corrected the case of the imported Class